### PR TITLE
Update base_request.go to omit empty fields

### DIFF
--- a/minfraud/base_request.go
+++ b/minfraud/base_request.go
@@ -46,7 +46,7 @@ type CreditCardData struct {
 	IssuerIDNumber        string `json:"issuer_id_number,omitempty"`
 	Last4Digits           string `json:"last_4_digits,omitempty"`
 	Token                 string `json:"token,omitempty"`
-	Was3DSecureSuccessful bool   `json:"was_3d_secure_successful,omitempty"`
+	Was3DSecureSuccessful *bool   `json:"was_3d_secure_successful,omitempty"`
 }
 
 type DeviceData struct {
@@ -71,11 +71,11 @@ type EventData struct {
 
 type OrderData struct {
 	AffiliateID    string  `json:"affiliateID,omitempty"`
-	Amount         float64 `json:"amount,omitempty"`
+	Amount         *float64 `json:"amount,omitempty"`
 	Currency       string  `json:"currency,omitempty"`
 	DiscountCode   string  `json:"discount_code,omitempty"`
-	HasGiftMessage bool    `json:"has_gift_message,omitempty"`
-	IsGift         bool    `json:"is_gift,omitempty"`
+	HasGiftMessage *bool    `json:"has_gift_message,omitempty"`
+	IsGift         *bool    `json:"is_gift,omitempty"`
 	ReferrerURI    string  `json:"referrer_uri,omitempty"`
 	SubaffiliateID string  `json:"subaffiliate_id,omitempty"`
 }
@@ -83,7 +83,7 @@ type OrderData struct {
 type PaymentData struct {
 	DeclineCode   string `json:"decline_code,omitempty"`
 	Processor     string `json:"processor,omitempty"`
-	WasAuthorized bool   `json:"was_authorized,omitempty"`
+	WasAuthorized *bool   `json:"was_authorized,omitempty"`
 }
 
 type ShippingData struct {
@@ -104,6 +104,6 @@ type ShippingData struct {
 type ShoppingCartData struct {
 	Category string  `json:"category,omitempty"`
 	ItemID   string  `json:"item_id,omitempty"`
-	Price    float64 `json:"price,omitempty"`
-	Quantity int64   `json:"quantity,omitempty"`
+	Price    *float64 `json:"price,omitempty"`
+	Quantity *int64   `json:"quantity,omitempty"`
 }

--- a/minfraud/base_request.go
+++ b/minfraud/base_request.go
@@ -19,42 +19,42 @@ type BaseRequest struct {
 }
 
 type AccountData struct {
-	UserID      string `json:"user_id"`
-	UserNameMD5 string `json:"username_md5"`
+	UserID      string `json:"user_id,omitempty"`
+	UserNameMD5 string `json:"username_md5,omitempty"`
 }
 
 type BillingData struct {
-	Address          string `json:"address"`
-	Address2         string `json:"address_2"`
-	City             string `json:"city"`
-	Company          string `json:"company"`
-	Country          string `json:"country"`
-	FirstName        string `json:"first_name"`
-	LastName         string `json:"last_name"`
-	PhoneCountryCode string `json:"phone_country_code"`
-	PhoneNumber      string `json:"phone_number"`
-	Postal           string `json:"postal"`
-	Region           string `json:"region"`
+	Address          string `json:"address,omitempty"`
+	Address2         string `json:"address_2,omitempty"`
+	City             string `json:"city,omitempty"`
+	Company          string `json:"company,omitempty"`
+	Country          string `json:"country,omitempty"`
+	FirstName        string `json:"first_name,omitempty"`
+	LastName         string `json:"last_name,omitempty"`
+	PhoneCountryCode string `json:"phone_country_code,omitempty"`
+	PhoneNumber      string `json:"phone_number,omitempty"`
+	Postal           string `json:"postal,omitempty"`
+	Region           string `json:"region,omitempty"`
 }
 
 type CreditCardData struct {
-	AVSResult             string `json:"avs_result"`
-	BankName              string `json:"bank_name"`
-	BankPhoneCountryCode  string `json:"bank_phone_country_code"`
-	BankPhoneNumber       string `json:"bank_phone_number"`
-	CVVResult             string `json:"cvv_result"`
-	IssuerIDNumber        string `json:"issuer_id_number"`
-	Last4Digits           string `json:"last_4_digits"`
-	Token                 string `json:"token"`
-	Was3DSecureSuccessful bool   `json:"was_3d_secure_successful"`
+	AVSResult             string `json:"avs_result,omitempty"`
+	BankName              string `json:"bank_name,omitempty"`
+	BankPhoneCountryCode  string `json:"bank_phone_country_code,omitempty"`
+	BankPhoneNumber       string `json:"bank_phone_number,omitempty"`
+	CVVResult             string `json:"cvv_result,omitempty"`
+	IssuerIDNumber        string `json:"issuer_id_number,omitempty"`
+	Last4Digits           string `json:"last_4_digits,omitempty"`
+	Token                 string `json:"token,omitempty"`
+	Was3DSecureSuccessful bool   `json:"was_3d_secure_successful,omitempty"`
 }
 
 type DeviceData struct {
-	AcceptLanguage string  `json:"accept_language"`
-	IPAddress      string  `json:"ip_address"`
-	SessionAge     float64 `json:"session_age"`
-	SessionID      string  `json:"session_id"`
-	UserAgent      string  `json:"user_agent"`
+	AcceptLanguage string  `json:"accept_language,omitempty"`
+	IPAddress      string  `json:"ip_address,omitempty"`
+	SessionAge     float64 `json:"session_age,omitempty"`
+	SessionID      string  `json:"session_id,omitempty"`
+	UserAgent      string  `json:"user_agent,omitempty"`
 }
 
 type EmailData struct {
@@ -63,47 +63,47 @@ type EmailData struct {
 }
 
 type EventData struct {
-	ShopID        string `json:"shop_id"`
-	Time          string `json:"time"`
-	TransactionID string `json:"transaction_id"`
-	Type          string `json:"type"`
+	ShopID        string `json:"shop_id,omitempty"`
+	Time          string `json:"time,omitempty"`
+	TransactionID string `json:"transaction_id,omitempty"`
+	Type          string `json:"type,omitempty"`
 }
 
 type OrderData struct {
-	AffiliateID    string  `json:"affiliateID"`
-	Amount         float64 `json:"amount"`
-	Currency       string  `json:"currency"`
-	DiscountCode   string  `json:"discount_code"`
-	HasGiftMessage bool    `json:"has_gift_message"`
-	IsGift         bool    `json:"is_gift"`
-	ReferrerURI    string  `json:"referrer_uri"`
-	SubaffiliateID string  `json:"subaffiliate_id"`
+	AffiliateID    string  `json:"affiliateID,omitempty"`
+	Amount         float64 `json:"amount,omitempty"`
+	Currency       string  `json:"currency,omitempty"`
+	DiscountCode   string  `json:"discount_code,omitempty"`
+	HasGiftMessage bool    `json:"has_gift_message,omitempty"`
+	IsGift         bool    `json:"is_gift,omitempty"`
+	ReferrerURI    string  `json:"referrer_uri,omitempty"`
+	SubaffiliateID string  `json:"subaffiliate_id,omitempty"`
 }
 
 type PaymentData struct {
-	DeclineCode   string `json:"decline_code"`
-	Processor     string `json:"processor"`
-	WasAuthorized bool   `json:"was_authorized"`
+	DeclineCode   string `json:"decline_code,omitempty"`
+	Processor     string `json:"processor,omitempty"`
+	WasAuthorized bool   `json:"was_authorized,omitempty"`
 }
 
 type ShippingData struct {
-	Address          string `json:"address"`
-	Address2         string `json:"address_2"`
-	City             string `json:"city"`
-	Company          string `json:"company"`
-	Country          string `json:"country"`
-	DeliverySpeed    string `json:"delivery_speed"`
-	FirstName        string `json:"first_name"`
-	LastName         string `json:"last_name"`
-	PhoneCountryCode string `json:"phone_country_code"`
-	PhoneNumber      string `json:"phone_number"`
-	Postal           string `json:"postal"`
-	Region           string `json:"region"`
+	Address          string `json:"address,omitempty"`
+	Address2         string `json:"address_2,omitempty"`
+	City             string `json:"city,omitempty"`
+	Company          string `json:"company,omitempty"`
+	Country          string `json:"country,omitempty"`
+	DeliverySpeed    string `json:"delivery_speed,omitempty"`
+	FirstName        string `json:"first_name,omitempty"`
+	LastName         string `json:"last_name,omitempty"`
+	PhoneCountryCode string `json:"phone_country_code,omitempty"`
+	PhoneNumber      string `json:"phone_number,omitempty"`
+	Postal           string `json:"postal,omitempty"`
+	Region           string `json:"region,omitempty"`
 }
 
 type ShoppingCartData struct {
-	Category string  `json:"category"`
-	ItemID   string  `json:"item_id"`
-	Price    float64 `json:"price"`
-	Quantity int64   `json:"quantity"`
+	Category string  `json:"category,omitempty"`
+	ItemID   string  `json:"item_id,omitempty"`
+	Price    float64 `json:"price,omitempty"`
+	Quantity int64   `json:"quantity,omitempty"`
 }


### PR DESCRIPTION
Without omitempty, it is impossible to submit sparse inputs to the MinFraud API. The MinFraud API is designed in a way which allows for use even if not every field has a value, but without omitempty, these values are parsed into JSON as the zero-value of the type (empty strings, 0, etc.) rather than not including it in the JSON request.

An example of this, in BillingData, is where we have the billing address of the transaction, but not the ISO 3166-2 region code. With the current type, an empty string is passed and MinFraud returns an error "Encountered value at /billing/region that does not meet the required constraints."

This means it is impossible to pass BillingData without a region code, even though this is a valid use of the API.

By setting omitempty on all fields, we allow the developer to decide which fields to pass.

## Potential Risks
### Fields where zero-value may be used
The only downside of this approach is omitempty removes the ability to pass zero-value entries.

This does not seem a problem, except for these fields, as a "free" item (Price = 0) is a valid option, and the same for amount
```
Amount float64 `json:"amount,omitempty"`
...
Price float64 `json:"price,omitempty"`
```

### Bools (Zero-value of false)
With omitempty, any booleans explicity set to false will be omitted, as this is the zero-value for a boolean. This is not desirable, as clearly "false" is a valid input and should not be omitted

### Solution
I will update this PR to use pointers for these specific fields to fix the above issue.

